### PR TITLE
Implement D0-D3 instructions

### DIFF
--- a/x86il/InterpretCpu.cs
+++ b/x86il/InterpretCpu.cs
@@ -514,6 +514,18 @@ namespace x86il
                     case 0xcd:
                         Interrupt();
                         break;
+                    case 0xd0:
+                        ShiftGroup(RegisterType.reg8, false);
+                        break;
+                    case 0xd1:
+                        ShiftGroup(RegisterType.reg16, false);
+                        break;
+                    case 0xd2:
+                        ShiftGroup(RegisterType.reg8, true);
+                        break;
+                    case 0xd3:
+                        ShiftGroup(RegisterType.reg16, true);
+                        break;
                     case 0xfe:
                         Inc8();
                         break;
@@ -535,19 +547,21 @@ namespace x86il
         private void ModRm(Func<ushort, uint, uint> function,
             RegisterType r1Type = RegisterType.reg8,
             bool rmFirst = true,
-            bool useResult = true)
+            bool useResult = true,
+            bool setFlags = true)
         {
             var executor = GetExecutor(r1Type);
-            ModRm(function, executor, rmFirst, useResult);
+            ModRm(function, executor, rmFirst, useResult, setFlags);
         }
 
         private void ModRm(Func<ushort, uint, uint> function,
             ModRmExecutor executor,
             bool rmFirst = true,
-            bool useResult = true)
+            bool useResult = true,
+            bool setFlags = true)
         {
             _decoder.Decode(_ip);
-            executor.Execute(function, rmFirst, useResult);
+            executor.Execute(function, rmFirst, useResult, setFlags);
             _ip += _decoder.IpShift;
         }
 
@@ -977,6 +991,183 @@ namespace x86il
         {
             if (bytes == 1) return _memory[_ip + 2];
             return BinaryHelper.Read16Bit(_memory, _ip + 2);
+        }
+
+        private void ShiftGroup(RegisterType type, bool useCl)
+        {
+            int count = useCl ? registers.Get(Reg8.cl) : 1;
+            bool modify = count != 0;
+
+            ModRm((r1, value) =>
+            {
+                // _decoder is decoded inside ModRm
+                if (!modify)
+                    return value;
+
+                int bits = type == RegisterType.reg8 ? 8 : 16;
+                uint mask = (uint)((1 << bits) - 1);
+
+                value &= mask;
+                count &= 0x1f;
+                return ExecuteShift(_decoder.R1, value, count, bits);
+            }, type, false, modify, modify);
+        }
+
+        private uint ExecuteShift(int opcode, uint value, int count, int bits)
+        {
+            switch (opcode)
+            {
+                case 0x0:
+                    return Rol(value, count, bits);
+                case 0x1:
+                    return Ror(value, count, bits);
+                case 0x2:
+                    return Rcl(value, count, bits);
+                case 0x3:
+                    return Rcr(value, count, bits);
+                case 0x4:
+                case 0x6:
+                    return Shl(value, count, bits);
+                case 0x5:
+                    return Shr(value, count, bits);
+                case 0x7:
+                    return Sar(value, count, bits);
+                default:
+                    throw new NotImplementedException($"ShiftGroup opcode {opcode} not implemented");
+            }
+        }
+
+        private uint Rol(uint value, int count, int bits)
+        {
+            count %= bits;
+            uint result = ((value << count) | (value >> (bits - count))) & ((uint)(1 << bits) - 1);
+            flagsRegister.SetFlagBasedOnResult(Flags.Carry, (result & 1) != 0);
+            if (count == 1)
+            {
+                bool msb = ((result >> (bits - 1)) & 1) != 0;
+                bool sec = ((result >> (bits - 2)) & 1) != 0;
+                flagsRegister.SetFlagBasedOnResult(Flags.Overflow, msb ^ sec);
+            }
+            flagsRegister.CheckZero((int)result, 0, 0);
+            flagsRegister.CheckSign(result, bits / 8);
+            flagsRegister.CheckParity((int)result);
+            return result;
+        }
+
+        private uint Ror(uint value, int count, int bits)
+        {
+            count %= bits;
+            uint result = ((value >> count) | (value << (bits - count))) & ((uint)(1 << bits) - 1);
+            flagsRegister.SetFlagBasedOnResult(Flags.Carry, ((result >> (bits - 1)) & 1) != 0);
+            if (count == 1)
+            {
+                bool msb = ((result >> (bits - 1)) & 1) != 0;
+                bool sec = ((result >> (bits - 2)) & 1) != 0;
+                flagsRegister.SetFlagBasedOnResult(Flags.Overflow, msb ^ sec);
+            }
+            flagsRegister.CheckZero((int)result, 0, 0);
+            flagsRegister.CheckSign(result, bits / 8);
+            flagsRegister.CheckParity((int)result);
+            return result;
+        }
+
+        private uint Rcl(uint value, int count, int bits)
+        {
+            uint mask = (uint)((1 << bits) - 1);
+            uint cf = flagsRegister.HasFlag(Flags.Carry) ? 1u : 0u;
+            for (int i = 0; i < count; i++)
+            {
+                uint newCf = (value >> (bits - 1)) & 1u;
+                value = ((value << 1) | cf) & mask;
+                cf = newCf;
+            }
+            flagsRegister.SetFlagBasedOnResult(Flags.Carry, cf != 0);
+            if (count == 1)
+            {
+                bool msb = ((value >> (bits - 1)) & 1) != 0;
+                flagsRegister.SetFlagBasedOnResult(Flags.Overflow, msb ^ (cf != 0));
+            }
+            flagsRegister.CheckZero((int)value, 0, 0);
+            flagsRegister.CheckSign(value, bits / 8);
+            flagsRegister.CheckParity((int)value);
+            return value & mask;
+        }
+
+        private uint Rcr(uint value, int count, int bits)
+        {
+            uint mask = (uint)((1 << bits) - 1);
+            uint cf = flagsRegister.HasFlag(Flags.Carry) ? 1u : 0u;
+            for (int i = 0; i < count; i++)
+            {
+                uint newCf = value & 1u;
+                value = (value >> 1) | (cf << (bits - 1));
+                value &= mask;
+                cf = newCf;
+            }
+            flagsRegister.SetFlagBasedOnResult(Flags.Carry, cf != 0);
+            if (count == 1)
+            {
+                bool msb = ((value >> (bits - 1)) & 1) != 0;
+                flagsRegister.SetFlagBasedOnResult(Flags.Overflow, msb ^ ((cf != 0)));
+            }
+            flagsRegister.CheckZero((int)value, 0, 0);
+            flagsRegister.CheckSign(value, bits / 8);
+            flagsRegister.CheckParity((int)value);
+            return value & mask;
+        }
+
+        private uint Shl(uint value, int count, int bits)
+        {
+            uint mask = (uint)((1 << bits) - 1);
+            uint result = (value << count) & mask;
+            bool cf = ((value >> (bits - count)) & 1) != 0;
+            flagsRegister.SetFlagBasedOnResult(Flags.Carry, cf);
+            if (count == 1)
+            {
+                bool msb = ((result >> (bits - 1)) & 1) != 0;
+                flagsRegister.SetFlagBasedOnResult(Flags.Overflow, msb ^ cf);
+            }
+            flagsRegister.CheckZero((int)result, 0, 0);
+            flagsRegister.CheckSign(result, bits / 8);
+            flagsRegister.CheckParity((int)result);
+            return result;
+        }
+
+        private uint Shr(uint value, int count, int bits)
+        {
+            uint result = value >> count;
+            bool cf = ((value >> (count - 1)) & 1) != 0;
+            flagsRegister.SetFlagBasedOnResult(Flags.Carry, cf);
+            if (count == 1)
+            {
+                bool msbOrig = ((value >> (bits - 1)) & 1) != 0;
+                flagsRegister.SetFlagBasedOnResult(Flags.Overflow, msbOrig);
+            }
+            flagsRegister.CheckZero((int)result, 0, 0);
+            flagsRegister.CheckSign(result, bits / 8);
+            flagsRegister.CheckParity((int)result);
+            return result;
+        }
+
+        private uint Sar(uint value, int count, int bits)
+        {
+            uint mask = (uint)((1 << bits) - 1);
+            bool sign = ((value >> (bits - 1)) & 1) != 0;
+            uint result;
+            if (sign)
+                result = (uint)(((int)value) >> count) & mask;
+            else
+                result = value >> count;
+            bool cf = ((value >> (count - 1)) & 1) != 0;
+            flagsRegister.SetFlagBasedOnResult(Flags.Carry, cf);
+            if (count == 1)
+            {
+                flagsRegister.SetFlagBasedOnResult(Flags.Overflow, false);
+            }
+            flagsRegister.CheckZero((int)result, 0, 0);
+            flagsRegister.CheckSign(result, bits / 8);
+            flagsRegister.CheckParity((int)result);
+            return result & mask;
         }
 
         private void Handle0X8X(RegisterType registerType, int immBytes, string instruction)

--- a/x86il/InterpretCpu.cs
+++ b/x86il/InterpretCpu.cs
@@ -1152,12 +1152,18 @@ namespace x86il
         private uint Sar(uint value, int count, int bits)
         {
             uint mask = (uint)((1 << bits) - 1);
-            bool sign = ((value >> (bits - 1)) & 1) != 0;
             uint result;
-            if (sign)
-                result = (uint)(((int)value) >> count) & mask;
+
+            if (bits == 8)
+            {
+                int sval = (sbyte)(value & mask);
+                result = (uint)(sval >> count) & mask;
+            }
             else
-                result = value >> count;
+            {
+                int sval = (short)(value & mask);
+                result = (uint)(sval >> count) & mask;
+            }
             bool cf = ((value >> (count - 1)) & 1) != 0;
             flagsRegister.SetFlagBasedOnResult(Flags.Carry, cf);
             if (count == 1)

--- a/x86il/ModRmExecutor.cs
+++ b/x86il/ModRmExecutor.cs
@@ -21,12 +21,13 @@ namespace x86il
         protected abstract RegisterType RegisterType { get; }
         protected abstract RegisterType ComplementRegisterType { get; }
 
-        public void RmResult(Func<ushort, uint, uint> function, bool rmFirst, bool useResult)
+        public void RmResult(Func<ushort, uint, uint> function, bool rmFirst, bool useResult, bool setFlags)
         {
             var r1Value = registers.Get(decoder.R1, RegisterType);
             var memValue = ReadMemory();
             var res = function(r1Value, memValue);
-            flagsRegister.SetFlagsFromInputAndResult((int) res, r1Value, memValue, RegisterType.ToNumBytes());
+            if (setFlags)
+                flagsRegister.SetFlagsFromInputAndResult((int) res, r1Value, memValue, RegisterType.ToNumBytes());
             if (useResult) RmFunc(res, rmFirst);
         }
 
@@ -47,22 +48,23 @@ namespace x86il
             registers.Set(rmFirst ? decoder.R1 : decoder.R2, (ushort) res, RegisterType);
         }
 
-        public void RegResult(Func<ushort, uint, uint> function, bool rmFirst, bool useResult)
+        public void RegResult(Func<ushort, uint, uint> function, bool rmFirst, bool useResult, bool setFlags)
         {
             var r1Value = registers.Get(decoder.R1, RegisterType);
             var r2Value = registers.Get(decoder.R2, ComplementRegisterType);
             var result = function(registers.Get(decoder.R1, RegisterType),
                 registers.Get(decoder.R2, ComplementRegisterType));
-            flagsRegister.SetFlagsFromInputAndResult((int) result, r1Value, r2Value, RegisterType.ToNumBytes());
+            if (setFlags)
+                flagsRegister.SetFlagsFromInputAndResult((int) result, r1Value, r2Value, RegisterType.ToNumBytes());
             if (useResult) RegFunc((ushort) result, rmFirst);
         }
 
-        public void Execute(Func<ushort, uint, uint> function, bool rmFirst, bool useResult)
+        public void Execute(Func<ushort, uint, uint> function, bool rmFirst, bool useResult, bool setFlags)
         {
             if (decoder.Type == ModRMType.RM)
-                RmResult(function, rmFirst, useResult);
+                RmResult(function, rmFirst, useResult, setFlags);
             else
-                RegResult(function, rmFirst, useResult);
+                RegResult(function, rmFirst, useResult, setFlags);
         }
     }
 }

--- a/x86ilTests/InterpretCpuTests.cs
+++ b/x86ilTests/InterpretCpuTests.cs
@@ -765,5 +765,68 @@ namespace x86il.Tests
             Assert.AreEqual(0x4815, cpu.GetRegister(Reg16.di));
             Assert.AreEqual(0x1623, cpu.GetRegister(Reg16.ax));
         }
+
+        [Test]
+        public void ExecuteTestRolBl1()
+        {
+            var cpu = RunAsmTest("RolBl1");
+            Assert.AreEqual(4, cpu.GetRegister(Reg8.bl));
+        }
+
+        [Test]
+        public void ExecuteTestRorBl1()
+        {
+            var cpu = RunAsmTest("RorBl1");
+            Assert.AreEqual(2, cpu.GetRegister(Reg8.bl));
+        }
+
+        [Test]
+        public void ExecuteTestRclBl1()
+        {
+            var cpu = RunAsmTest("RclBl1");
+            Assert.AreEqual(11, cpu.GetRegister(Reg8.bl));
+        }
+
+        [Test]
+        public void ExecuteTestRcrBl1()
+        {
+            var cpu = RunAsmTest("RcrBl1");
+            Assert.AreEqual(0x84, cpu.GetRegister(Reg8.bl));
+        }
+
+        [Test]
+        public void ExecuteTestShlBl1()
+        {
+            var cpu = RunAsmTest("ShlBl1");
+            Assert.AreEqual(6, cpu.GetRegister(Reg8.bl));
+        }
+
+        [Test]
+        public void ExecuteTestShrBl1()
+        {
+            var cpu = RunAsmTest("ShrBl1");
+            Assert.AreEqual(2, cpu.GetRegister(Reg8.bl));
+        }
+
+        [Test]
+        public void ExecuteTestSarBl1()
+        {
+            var cpu = RunAsmTest("SarBl1");
+            Assert.AreEqual(0xf8, cpu.GetRegister(Reg8.bl));
+        }
+
+        [Test]
+        public void ExecuteTestShlBlCl()
+        {
+            var cpu = RunAsmTest("ShlBlCl");
+            Assert.AreEqual(12, cpu.GetRegister(Reg8.bl));
+        }
+
+        [Test]
+        public void ExecuteTestRolBxCl()
+        {
+            var cpu = RunAsmTest("RolBxCl");
+            Assert.AreEqual(4, cpu.GetRegister(Reg16.bx));
+        }
     }
 }

--- a/x86ilTests/TestAsm/RclBl1.asm
+++ b/x86ilTests/TestAsm/RclBl1.asm
@@ -1,0 +1,5 @@
+mov ah, 4
+mov bh, 255
+add ah, bh
+mov bl, 5
+rcl bl, 1

--- a/x86ilTests/TestAsm/RcrBl1.asm
+++ b/x86ilTests/TestAsm/RcrBl1.asm
@@ -1,0 +1,5 @@
+mov ah, 4
+mov bh, 255
+add ah, bh
+mov bl, 8
+rcr bl, 1

--- a/x86ilTests/TestAsm/RolBl1.asm
+++ b/x86ilTests/TestAsm/RolBl1.asm
@@ -1,0 +1,2 @@
+mov bl, 2
+rol bl, 1

--- a/x86ilTests/TestAsm/RolBxCl.asm
+++ b/x86ilTests/TestAsm/RolBxCl.asm
@@ -1,0 +1,3 @@
+mov cl, 1
+mov bx, 2
+rol bx, cl

--- a/x86ilTests/TestAsm/RorBl1.asm
+++ b/x86ilTests/TestAsm/RorBl1.asm
@@ -1,0 +1,2 @@
+mov bl, 4
+ror bl, 1

--- a/x86ilTests/TestAsm/SarBl1.asm
+++ b/x86ilTests/TestAsm/SarBl1.asm
@@ -1,0 +1,2 @@
+mov bl, 0xf0
+sar bl, 1

--- a/x86ilTests/TestAsm/ShlBl1.asm
+++ b/x86ilTests/TestAsm/ShlBl1.asm
@@ -1,0 +1,2 @@
+mov bl, 3
+shl bl, 1

--- a/x86ilTests/TestAsm/ShlBlCl.asm
+++ b/x86ilTests/TestAsm/ShlBlCl.asm
@@ -1,0 +1,3 @@
+mov cl, 2
+mov bl, 3
+shl bl, cl

--- a/x86ilTests/TestAsm/ShrBl1.asm
+++ b/x86ilTests/TestAsm/ShrBl1.asm
@@ -1,0 +1,2 @@
+mov bl, 4
+shr bl, 1

--- a/x86ilTests/x86ilTests.csproj
+++ b/x86ilTests/x86ilTests.csproj
@@ -357,6 +357,33 @@
     <Content Include="TestAsm\zeroes2.asm">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestAsm\RolBl1.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestAsm\RorBl1.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestAsm\RclBl1.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestAsm\RcrBl1.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestAsm\ShlBl1.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestAsm\ShrBl1.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestAsm\SarBl1.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestAsm\ShlBlCl.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestAsm\RolBxCl.asm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
## Summary
- add opcodes D0-D3 in InterpretCpu
- implement `ShiftGroup` helper for rotate/shift operations
- include rotate/shift helpers: Rol, Ror, Rcl, Rcr, Shl, Shr, Sar
- refactor `ShiftGroup` to rely on existing ModRm helper

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5afc2a14832fac206f6961c58046